### PR TITLE
Throughput usunięte

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -543,7 +543,7 @@ PrefabInstance:
     - target: {fileID: 4108035953836294421, guid: 145f415917ecdcd459fe5584793d9aaf,
         type: 3}
       propertyPath: _throughput
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4349449765655347737, guid: 145f415917ecdcd459fe5584793d9aaf,
         type: 3}
@@ -1896,7 +1896,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bab648a4cfdfd4e4f8ad72527cd28762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  simSpeed: 1
 --- !u!4 &1391896451
 Transform:
   m_ObjectHideFlags: 0
@@ -2981,6 +2980,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Machine 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4108035953836294421, guid: 145f415917ecdcd459fe5584793d9aaf,
+        type: 3}
+      propertyPath: _throughput
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8114655119567397873, guid: 145f415917ecdcd459fe5584793d9aaf,
         type: 3}

--- a/Assets/Scripts/SimView/MachinePanel.cs
+++ b/Assets/Scripts/SimView/MachinePanel.cs
@@ -9,7 +9,6 @@ public class MachinePanel : MonoBehaviour
 
     public GameObject machineID;
     public GameObject processingTime;
-    public GameObject throughput;
 
     public GameObject breakeChance;
     private Text _breakeChance;
@@ -20,7 +19,6 @@ public class MachinePanel : MonoBehaviour
 
         machineID.GetComponent<Text>().text = Machine.name;
         processingTime.GetComponentInChildren<Text>().text = Machine.ProcessingTime.ToString();
-        throughput.GetComponentInChildren<Text>().text = Machine.Throughput.ToString();
     }
 
     private void Update()
@@ -31,10 +29,5 @@ public class MachinePanel : MonoBehaviour
     public void OnEndEdit_ProcessingTime(string value)
     {
         Machine.ProcessingTime = float.Parse(value);
-    }
-
-    public void OnEndEdit_Throughput(string value)
-    {
-        Machine.Throughput = int.Parse(value);
     }
 }

--- a/Assets/Scripts/Spliter.cs
+++ b/Assets/Scripts/Spliter.cs
@@ -92,8 +92,7 @@ public class Spliter : MonoBehaviour
         float total = 0;
         for (int i = 0; i < m_templateRoutesForPastaParticle.Count; i++)
         {
-            _autoPastaDistribution[i] = (m_templateRoutesForPastaParticle[i].list[0].GetComponent<Machine>().Throughput /
-                                     m_templateRoutesForPastaParticle[i].list[0].GetComponent<Machine>().ProcessingTime);
+            _autoPastaDistribution[i] = 1/m_templateRoutesForPastaParticle[i].list[0].GetComponent<Machine>().ProcessingTime;
             total += _autoPastaDistribution[i];
         }
 


### PR DESCRIPTION
Wróciłem tutaj do starej koncepcji, w której sterując Pasta Particle, nie manipuluję ani na List<Game Object> ani na Game Object - tylko na Component z Game Object. Wszystko wygląda dobrze, nie wiem natomiast czemu, nie chcą przejeżdżać ciężarówki z ostatniego Storehouse do Składu Makaronu (czy myśmy nie mieli tego problemu w wcześniejszej wersji?).